### PR TITLE
Add missing v0-to-v1 conversion pitfalls from traversaro/conda-recipe-v0-to-v1-conversion-prompt

### DIFF
--- a/recipes/conda-forge/references/rattler-build-migration.md
+++ b/recipes/conda-forge/references/rattler-build-migration.md
@@ -82,6 +82,12 @@ Use this when feedrattler fails or produces an incorrect conversion.
 | Test commands | `test.commands` | `tests[].script` |
 | Package contents tests | not available | `tests[].package_contents` |
 | Build script | `build.script` | `build.script` (list of strings) |
+| `run_exports` location | `build.run_exports` | `requirements.run_exports` |
+| `run_constrained` | `requirements.run_constrained` | `requirements.run_constraints` |
+| `ignore_run_exports` | `build.ignore_run_exports` | `requirements.ignore_run_exports.by_name` |
+| `skip` syntax | `build: skip: true  # [win]` | `build: skip: [win]` |
+| `about` home field | `about.home` | `about.homepage` |
+| Build string hash | `h{{ PKG_HASH }}` | `h${{ hash }}` |
 
 ### Common conversion pitfalls
 
@@ -97,3 +103,54 @@ Use this when feedrattler fails or produces an incorrect conversion.
 ```
 - Test section restructuring: v1 uses a list of test objects
 - `pin_subpackage` and `pin_compatible` syntax changes
+- `skip` syntax changed: `build: skip: true  # [win]` becomes
+```yaml
+build:
+  skip:
+    - win
+```
+See https://rattler.build/latest/reference/recipe_file/#skipping-builds for details.
+- `run_exports` moved from `build:` to `requirements:`, and `max_pin` renamed to `upper_bound`:
+```yaml
+# v0
+build:
+  run_exports:
+    - {{ pin_subpackage('pkg', max_pin='x') }}
+# v1
+requirements:
+  run_exports:
+    - ${{ pin_subpackage('pkg', upper_bound='x') }}
+```
+- `run_constrained` renamed to `run_constraints`
+- `ignore_run_exports` moved from `build:` to `requirements:` with restructured keys:
+```yaml
+# v0
+build:
+  ignore_run_exports:
+    - zlib
+  ignore_run_exports_from:
+    - zlib
+# v1
+requirements:
+  ignore_run_exports:
+    by_name:
+      - zlib
+    from_package:
+      - zlib
+```
+- Remove `pip check` from test commands / scripts — it is automatically handled inside `tests[].python.imports:`
+- `about.home` renamed to `about.homepage` (required by the conda-forge linter)
+- `PKG_HASH` replaced by `hash`; `PKG_BUILDNUM` has no direct equivalent (define a context variable instead):
+```yaml
+# v0
+build:
+  string: {{ string_prefix }}_h{{ PKG_HASH }}
+# v1
+build:
+  string: ${{ string_prefix }}_h${{ hash }}
+```
+- Keep using implicit `build.sh` / `build.bat` scripts rather than embedding commands in the recipe; note that on Windows the implicit script name changed from `bld.bat` (v0) to `build.bat` (v1) — call it explicitly to avoid renaming it
+- noarch python recipes: use `python_min` from the conda-forge pinning for host/run/test constraints
+  - host: `- python ${{ python_min }}.*`
+  - run: `- python >=${{ python_min }}`
+  - test `python_version`: `${{ python_min }}.*`


### PR DESCRIPTION
This PR integrates missing conversion details from https://github.com/traversaro/conda-recipe-v0-to-v1-conversion-prompt into the rattler-build migration reference.

Added to the differences table and pitfalls section:
- `run_exports` moved from `build:` to `requirements:` (and `max_pin` → `upper_bound`)
- `run_constrained` renamed to `run_constraints`
- `ignore_run_exports` / `ignore_run_exports_from` moved from `build:` to `requirements:` with `by_name`/`from_package` subkeys
- `skip` syntax change
- Remove `pip check` from test scripts (handled automatically by `tests[].python.imports`)
- `about.home` renamed to `about.homepage`
- `PKG_HASH` → `hash`, `PKG_BUILDNUM` has no direct equivalent
- Keep using implicit `build.sh`/`build.bat` scripts; note Windows implicit script changed from `bld.bat` to `build.bat`
- noarch python: use `python_min` from conda-forge pinning for host/run/test

*This PR was opened by an agent (GitHub Copilot) on behalf of @traversaro. If it looks wrong/sloppy/inappropriate, please report it here: https://github.com/traversaro/conda-forge-agent-ws*