### PR TITLE
fix typo, use `rattler-build publish` with trusted publishing

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -79,25 +79,7 @@ jobs:
         with:
           name: output
           path: output
-      - name: Get JWT
-        id: get_token
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: |
-            const token = await core.getIDToken('prefix.dev')
-            core.setOutput('token', token)
-      - name: Mint the API Key on prefix.dev
-        shell: bash
-        run: |
-          TOKEN="${{ steps.get_token.outputs.token }}"
-          RESPONSE="$(curl -s -X POST                 \
-              https://prefix.dev/api/oidc/mint_token \
-              -H 'Content-Type: application/json'    \
-              --data "{\"token\": \"$TOKEN\"}")"
-          # mask the response
-          echo "::add-mask::$RESPONSE"
-          echo "PREFIX_API_KEY=$RESPONSE" >> "$GITHUB_ENV"
       - name: Upload package to prefix.dev
         if: github.event_name == 'push'
         run: |
-          rattler-build upload prefix --generate-attestation -c skill-forge output/**/*.conda
+          rattler-build publish --to https://prefix.dev/skill-forge --generate-attestation output/**/*.conda

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -97,7 +97,7 @@ jobs:
           # mask the response
           echo "::add-mask::$RESPONSE"
           echo "PREFIX_API_KEY=$RESPONSE" >> "$GITHUB_ENV"
-      - name: Upload package to Artifactory
+      - name: Upload package to prefix.dev
         if: github.event_name == 'push'
         run: |
           rattler-build upload prefix --generate-attestation -c skill-forge output/**/*.conda

--- a/recipes/polars/recipe.yaml
+++ b/recipes/polars/recipe.yaml
@@ -2,7 +2,7 @@ context:
   skill: polars
 package:
   name: agent-skill-${{ skill }}
-  version: "0.0.6"
+  version: "0.0.7"
 source:
   git: https://github.com/k-dense-ai/claude-scientific-skills
   rev: 575404d3c23ca9163b9bd4a7512d127522ccdc0d


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to switch package upload/publish target to prefix.dev.
  * Bumped package version for agent-skill from 0.0.6 to 0.0.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->