### PR TITLE
conda-forge: Mention inlining name

### DIFF
--- a/recipes/conda-forge/recipe.yaml
+++ b/recipes/conda-forge/recipe.yaml
@@ -3,7 +3,7 @@ context:
 
 package:
   name: agent-skill-${{ skill }}
-  version: "0.0.15"
+  version: "0.0.16"
 
 source:
   url: https://raw.githubusercontent.com/conda-forge/conda-forge.github.io/refs/heads/main/LICENSE

--- a/recipes/conda-forge/references/rattler-build-migration.md
+++ b/recipes/conda-forge/references/rattler-build-migration.md
@@ -105,3 +105,8 @@ Use this when feedrattler fails or produces an incorrect conversion.
 - Test section restructuring: v1 uses a list of test objects
 - `pin_subpackage` and `pin_compatible` syntax changes
 - skipping builds is done by listing skipping conditions under `build.skip`, not with selectors
+
+### Best practices
+
+Old `meta.yaml` recipes often contain something like `{% set name = "..." %}`. The `recipe.yaml` equivalent would be setting `context.name` appropriately.
+This should not be done anymore for modern recipes. Instead, inline the name in all used places.


### PR DESCRIPTION
noticed this when i used the rattler-build migration


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced the rattler-build v0→v1 migration guide with a new best practices section, providing updated guidance on recipe name handling and configuration patterns for modern recipes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->