### PR TITLE
conda-forge: Add go-licenses failure handling

### DIFF
--- a/recipes/conda-forge/SKILL.md
+++ b/recipes/conda-forge/SKILL.md
@@ -151,6 +151,7 @@ If a newer Python minimum is required than conda-forge's default (3.10), overrid
 - **Import errors in test phase**: Missing runtime dependency → add to `requirements.run`.
 - **Compilation failure**: Missing library → add to `requirements.host`.
 - **Command not found (exit 127)**: Missing build tool → add to `requirements.build`.
+- **one or more libraries have an incompatible/unknown license**: `go-license` often needs manual interventions, see [go-licenses.md](references/go-licenses.md).
 
 ### Key Decisions
 

--- a/recipes/conda-forge/SKILL.md
+++ b/recipes/conda-forge/SKILL.md
@@ -151,7 +151,7 @@ If a newer Python minimum is required than conda-forge's default (3.10), overrid
 - **Import errors in test phase**: Missing runtime dependency → add to `requirements.run`.
 - **Compilation failure**: Missing library → add to `requirements.host`.
 - **Command not found (exit 127)**: Missing build tool → add to `requirements.build`.
-- **one or more libraries have an incompatible/unknown license**: `go-license` often needs manual interventions, see [go-licenses.md](references/go-licenses.md).
+- **one or more libraries have an incompatible/unknown license**: `go-licenses` often needs manual interventions, see [go-licenses.md](references/go-licenses.md).
 
 ### Key Decisions
 

--- a/recipes/conda-forge/recipe.yaml
+++ b/recipes/conda-forge/recipe.yaml
@@ -3,7 +3,7 @@ context:
 
 package:
   name: agent-skill-${{ skill }}
-  version: "0.0.16"
+  version: "0.0.17"
 
 source:
   url: https://raw.githubusercontent.com/conda-forge/conda-forge.github.io/refs/heads/main/LICENSE

--- a/recipes/conda-forge/references/go-licenses.md
+++ b/recipes/conda-forge/references/go-licenses.md
@@ -1,16 +1,16 @@
 # go-licenses workaround
 
-If a go-based feedstock fails with build with `one or more libraries have an incompatible/unknown license`,
+If a go-based feedstock fails with `one or more libraries have an incompatible/unknown license`,
 this means that `go-licenses` was unable to recover a license from a package.
 Often, this license is included in the sources and you can manually copy it.
 
 As an example, the `github.com/alecthomas/chroma/v2` packages uses a `COPYING` file that is not detected.
-To fix it, we
+To fix it:
 
 1. Add `--ignore github.com/alecthomas/chroma/v2` to the `go-licenses` calls
 2. Manually copy over the license into the respective folder:
 
-```
+```yaml
 - if: win
   then:
     - for /f "delims=" %%i in ('dir /s /b gopath\chroma\COPYING') do mkdir ..\library_licenses\github.com\alecthomas\chroma\v2 & copy "%%i" ..\library_licenses\github.com\alecthomas\chroma\v2\COPYING

--- a/recipes/conda-forge/references/go-licenses.md
+++ b/recipes/conda-forge/references/go-licenses.md
@@ -1,0 +1,19 @@
+# go-licenses workaround
+
+If a go-based feedstock fails with build with `one or more libraries have an incompatible/unknown license`,
+this means that `go-licenses` was unable to recover a license from a package.
+Often, this license is included in the sources and you can manually copy it.
+
+As an example, the `github.com/alecthomas/chroma/v2` packages uses a `COPYING` file that is not detected.
+To fix it, we
+
+1. Add `--ignore github.com/alecthomas/chroma/v2` to the `go-licenses` calls
+2. Manually copy over the license into the respective folder:
+
+```
+- if: win
+  then:
+    - for /f "delims=" %%i in ('dir /s /b gopath\chroma\COPYING') do mkdir ..\library_licenses\github.com\alecthomas\chroma\v2 & copy "%%i" ..\library_licenses\github.com\alecthomas\chroma\v2\COPYING
+  else:
+    - find $SRC_DIR/gopath -path "*/chroma/*" -name "COPYING" -exec mkdir -p ../library_licenses/github.com/alecthomas/chroma/v2 \; -exec cp {} ../library_licenses/github.com/alecthomas/chroma/v2/COPYING \; -quit
+```


### PR DESCRIPTION
Before: [Qwen3.6-27B](https://huggingface.co/datasets/xhochy/conda-forge-agent-traces/blob/main/2026-06-18T06-19-06-116Z_019ed962-1c04-721b-98dd-5135645701b2.jsonl), [DeepSeek-V4-Flash](https://huggingface.co/datasets/xhochy/conda-forge-agent-traces/blob/main/2026-06-18T06-38-30-841Z_019ed973-e1b9-7f05-a431-327724dbfd9a.jsonl)

Afterwards: [Qwen3.6-27B](https://huggingface.co/datasets/xhochy/conda-forge-agent-traces/blob/main/2026-06-18T07-51-30-309Z_019ed9b6-b505-706c-bddc-8075cb979550.jsonl), [DeepSeek-V4-Flash](https://huggingface.co/datasets/xhochy/conda-forge-agent-traces/blob/main/2026-06-18T07-44-00-149Z_019ed9af-d695-7344-94d3-4064c0315ce6.jsonl)

While DeepSeek-V4-Flash managed to find a nice solution already from the start, it took a while whereas with the skill it directly knows what to do.

I found one-shotting this simpler to explain than writing a real cookbook. Verified this works on the [OpenTofu feedstock](https://github.com/conda-forge/opentofu-feedstock/pull/42) with Qwen3.6-27B: https://huggingface.co/datasets/xhochy/conda-forge-agent-traces/blob/main/2026-06-18T08-09-05-101Z_019ed9c6-cd4d-7ebf-b021-e7fc0b392cb3.jsonl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the troubleshooting guide with a new entry for license compatibility failures in Go feedstock builds, including links to additional guidance.
  * Added a dedicated Go-licenses workaround section with step-by-step instructions and an example, covering both Windows and non-Windows command variants to manually supply missing license files.
* **Chores**
  * Updated the packaged version from 0.0.16 to 0.0.17.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->