### PR TITLE
Add Quant Ranger custom updater skill

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -21,6 +21,9 @@ jobs:
             strategy: git-main
           - skill: pydantic-skills
             strategy: git-main
+          # github-latest-release strategy (track the latest GitHub release)
+          - skill: create-custom-updater
+            strategy: github-latest-release
           # generate strategy (re-run generate.py with latest rev)
           - skill: gws-cli
             strategy: generate

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ For more background on why distributing agent skills through package managers ma
 | Skill | Package | Description |
 |-------|---------|-------------|
 | [conda-forge](https://conda-forge.org) | `agent-skill-conda-forge` | conda-forge packaging operations |
+| [Quant Ranger one-off updater](https://ranger.quantco.cloud/docs/plugins/one-off-updaters) | `agent-skill-create-custom-updater` | Write and run one-off Quant Ranger custom updaters |
 | [Librarian](https://github.com/mitsuhiko/agent-stuff/tree/main/skills/librarian) | `agent-skill-librarian` | Cache and refresh remote git repository checkouts |
 | [Matplotlib Data Visualization](https://matplotlib.org) | `agent-skill-matplotlib-data-visualization` | Chart design and data storytelling guidelines |
 | Presentation Design | `agent-skill-presentation-design` | Slide design and storytelling guidelines |

--- a/recipes/create-custom-updater/recipe.yaml
+++ b/recipes/create-custom-updater/recipe.yaml
@@ -1,0 +1,47 @@
+context:
+  skill: create-custom-updater
+  version: "0.1.2"
+
+package:
+  name: agent-skill-${{ skill }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/Quantco/quant-ranger/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: fb10c5acb4e6fe42ee2ff78eac14ffed0e7378532da1a0c7c32109d07c4b47f3
+
+build:
+  number: 0
+  noarch: generic
+  script:
+    - mkdir -p $PREFIX/share/agent-skills/${{ skill }}
+    - cp -R skills/${{ skill }}/* $PREFIX/share/agent-skills/${{ skill }}
+
+requirements:
+  run_constraints:
+    - quant-ranger >=${{ version }}
+
+tests:
+  - package_contents:
+      files:
+        - share/agent-skills/${{ skill }}/SKILL.md
+      strict: true
+  - script:
+      - agentskills validate $CONDA_PREFIX/share/agent-skills/${{ skill }}
+    requirements:
+      run:
+        - skills-ref
+
+about:
+  summary: Write and run one-off quant-ranger custom updaters
+  description: |
+    Create narrow, idempotent one-off repository migrations with quant-ranger:
+    - Select repositories or files with built-in or custom scanners
+    - Apply or audit changes through typed custom update tasks
+    - Validate changes safely in dry-run mode before publishing pull requests
+    - Diagnose authentication, selection, subprocess, and publishing failures
+  homepage: https://ranger.quantco.cloud/docs/plugins/one-off-updaters
+  repository: https://github.com/Quantco/quant-ranger
+  documentation: https://ranger.quantco.cloud/docs/plugins/one-off-updaters
+  license: BSD-3-Clause
+  license_file: LICENSE


### PR DESCRIPTION
## Summary

- package Quant Ranger's `create-custom-updater` skill from the v0.1.2 release
- track future releases with the `github-latest-release` autobump strategy
- list the new package in the available-skills documentation

Addresses Quantco/quant-ranger#2